### PR TITLE
Fixes #306

### DIFF
--- a/prerequisites/install-functions/build_opencoarrays.sh
+++ b/prerequisites/install-functions/build_opencoarrays.sh
@@ -13,15 +13,15 @@ build_opencoarrays()
   if [[ -z ${MPIFC:-} || -z ${MPICC:-} ]]; then
     emergency "build_opencoarrays.sh: empty \${MPIFC}=${MPIFC:-} or \${MPICC}=${MPICC:-}"
   fi
-  MPIFC_show=`$MPIFC -show`
-  MPICC_show=`$MPICC -show`
-  if [[ ${MPIFC_show} != *gfortran* || ${MPICC_show} != *gcc* ]]; then
-    emergency "build_opencoarrays.sh: MPI doesn't wrap gfortran/gcc: \${MPIFC_show}=${MPIFC_show}, \${MPICC_show}=${MPICC_show}"
-  fi 
+  MPIFC_show=($($MPIFC -show))
+  MPICC_show=($($MPICC -show))
+  if [[ "${MPIFC_show[0]}" != *gfortran* || "${MPICC_show[0]}" != *gcc* ]]; then
+    emergency "build_opencoarrays.sh: MPI doesn't wrap gfortran/gcc: \${MPIFC_show}=${MPIFC_show[*]}, \${MPICC_show}=${MPICC_show[*]}"
+  fi
   # Set FC to the MPI implementation's gfortran command with any preceding path but without any subsequent arguments:
-  FC="${MPIFC_show%%gfortran*}"gfortran
+  FC="${MPIFC_show[0]}"
   # Set CC to the MPI implementation's gcc command...
-  CC="${MPICC_show%%gcc*}"gcc
+  CC="${MPICC_show[0]}"
   info "Configuring OpenCoarrays in ${PWD} with the command:"
   info "CC=\"${CC}\" FC=\"${FC}\" $CMAKE \"${opencoarrays_src_dir}\" -DCMAKE_INSTALL_PREFIX=\"${install_path}\" -DMPI_C_COMPILER=\"${MPICC}\" -DMPI_Fortran_COMPILER=\"${MPIFC}\""
   CC="${CC}" FC="${FC}" $CMAKE "${opencoarrays_src_dir}" -DCMAKE_INSTALL_PREFIX="${install_path}" -DMPI_C_COMPILER="${MPICC}" -DMPI_Fortran_COMPILER="${MPIFC}"


### PR DESCRIPTION
 Use bash array to extract compilers from `mpi{cc,f90} -show` rather
 than greedy parameter expansion which causes problems if compiler is in
 folders named e.g., gcc and/or if compiler has non-standard name.

 This closes #308 (pull request and supercedes/replaces 0ee37af)

@LaHaine can you please test this and confirm that it solves #305 and #306 for you? If it does, then merge this PR, and your PR against OpenCoarrays will be updated (and I'll close 308)

Thanks!